### PR TITLE
renamed zuul repositories

### DIFF
--- a/orgs/osism/repositories/zuul-config.yml
+++ b/orgs/osism/repositories/zuul-config.yml
@@ -1,5 +1,5 @@
 ---
-zuul_config:
+zuul-config:
   default_branch: main
   description: Zuul config
   homepage: https://zuul.osism.xyz/tenants
@@ -7,7 +7,7 @@ zuul_config:
   has_issues: true
   has_projects: false
   has_wiki: false
-  private: true
+  private: false
   delete_branch_on_merge: true
   allow_merge_commit: false
   allow_squash_merge: true

--- a/orgs/osism/repositories/zuul-jobs.yml
+++ b/orgs/osism/repositories/zuul-jobs.yml
@@ -1,5 +1,5 @@
 ---
-zuul_jobs:
+zuul-jobs:
   default_branch: main
   description: Zuul jobs
   homepage: https://zuul.osism.xyz/tenants


### PR DESCRIPTION
All repositories in osism are using a dash instead of an underscore. Therefore the zuul repositories should match this pattern

Closes osism/issues#181

Signed-off-by: Tim Beermann <beermann@osism.tech>
