### PR TITLE
Revert ansible-collection-gitcontrol submodule to upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "ansible-collection-gitcontrol"]
 	path = ansible-collection-gitcontrol
-	url = https://github.com/osfrickler/ansible-collection-gitcontrol
-	branch = bp
+	url = https://github.com/opentelekomcloud/ansible-collection-gitcontrol


### PR DESCRIPTION
The fix for ansible-collection-gitcontrol to be able to handle our
branch protection rules has been merged upstream, revert using a local
branch as submodule.

Closes: #55
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>