### PR TITLE
renamed ansible-wormhole repository to python-ansible-wormhole

### DIFF
--- a/orgs/osism/repositories/python-ansible-wormhole.yml
+++ b/orgs/osism/repositories/python-ansible-wormhole.yml
@@ -1,0 +1,30 @@
+---
+python-ansible-wormhole:
+  default_branch: main
+  description: Offline mirror for Ansible Galaxy
+  homepage: https://www.osism.tech
+  archived: false
+  has_issues: true
+  has_projects: false
+  has_wiki: false
+  private: false
+  delete_branch_on_merge: true
+  allow_merge_commit: false
+  allow_squash_merge: true
+  allow_rebase_merge: true
+  teams:
+    maintain:
+      - maintainers
+    pull:
+    push:
+    admin:
+      - admins
+  collaborators:
+    maintain:
+    pull:
+    push:
+    admin:
+  topics:
+    - ansible-wormhole
+    - ansible-galaxy
+    - ansible


### PR DESCRIPTION
Signed-off-by: Tim Beermann <beermann@osism.tech>
